### PR TITLE
Fix Overlay when not preserving truth particles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ SET( ${PROJECT_NAME}_VERSION_PATCH 0 )
 FIND_PACKAGE( ILCUTIL REQUIRED COMPONENTS ILCSOFT_CMAKE_MODULES )
 
 # load default settings from ILCSOFT_CMAKE_MODULES
-INCLUDE( ilcsoft_default_settings )
+#INCLUDE( ilcsoft_default_settings )
 
 
 FIND_PACKAGE( Marlin 1.0 REQUIRED ) # minimum required Marlin version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ SET( ${PROJECT_NAME}_VERSION_PATCH 0 )
 FIND_PACKAGE( ILCUTIL REQUIRED COMPONENTS ILCSOFT_CMAKE_MODULES )
 
 # load default settings from ILCSOFT_CMAKE_MODULES
-#INCLUDE( ilcsoft_default_settings )
+INCLUDE( ilcsoft_default_settings )
 
 
 FIND_PACKAGE( Marlin 1.0 REQUIRED ) # minimum required Marlin version

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -714,7 +714,7 @@ namespace overlay {
           }
         else if (source_collection->getTypeName() == LCIO::SIMTRACKERHIT) {
           //If truth is removed in the overlay, we need to remove the pointer since it will become invalid
-          if (_mergeMCParticles) {
+          if (not _mergeMCParticles) {
             for (int k = 0; k < number_of_elements; ++k) 
             {
               SimTrackerHitImpl *TrackerHit = static_cast<SimTrackerHitImpl*>(source_collection->getElementAt(k));


### PR DESCRIPTION
This PR correctly resets the links to the original truth particles when merging the overlay tracker hit collections from the BIB to the main collision event. The current setup woul keep the pointer to a value that becomes invalid and causes segmentation violation if tried to be used (and no way to say that it's invalid).

In the process, this PR also ensures the proper `Overlay` flag in simulated tracker hits is correctly set.

BEGINRELEASENOTES
- Fix Overlay algorithm to reset tracker hit pointers to Overlay MC particles when those are not preserved. Keep momentum information anyway before setting the link to a null pointer.
- Actually setting overlay flag in simulated tracker hit

ENDRELEASENOTES
