### PR TITLE
Bugfix for memory management

### DIFF
--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -560,6 +560,9 @@ namespace overlay {
         streamlog_out(DEBUG) << "Collection " << collection_names_in_evt->at(i) << " has now " << evt->getCollection(collection_names_in_evt->at(i))->getNumberOfElements() << " elements" << std::endl;
       }
 
+    // reset pointer
+    overlay_Evt = nullptr;
+    
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/OverlayTimingRandomMix.cc
+++ b/src/OverlayTimingRandomMix.cc
@@ -209,7 +209,7 @@ namespace overlay
       for (int k = 0; k < _NOverlay; ++k)
       {
         overlay_Eventfile_reader->open(_inputFileNamesMuPlus.at(v_file_indices_mupl[k]));
-        streamlog_out(MESSAGE) << "Open mu plus background file: " << _inputFileNamesMuPlus.at(v_file_indices_mupl[k]) << std::endl;
+        streamlog_out(MESSAGE) << "Open mu plus background file [" << k << "/" << _NOverlay << "]: " << _inputFileNamesMuPlus.at(v_file_indices_mupl[k]) << std::endl;
 
         overlay_Evt = overlay_Eventfile_reader->readNextEvent(LCIO::UPDATE);
 
@@ -323,7 +323,7 @@ namespace overlay
       for (int k = 0; k < _NOverlay; ++k)
       {
         overlay_Eventfile_reader->open(_inputFileNamesMuMinus.at(v_file_indices_mumi[k]));
-        streamlog_out(MESSAGE) << "Open mu minus background file: " << _inputFileNamesMuMinus.at(v_file_indices_mumi[k]) << std::endl;
+        streamlog_out(MESSAGE) << "Open mu minus background file [" << k << "/" << _NOverlay << "]: " << _inputFileNamesMuMinus.at(v_file_indices_mumi[k]) << std::endl;
 
         overlay_Evt = overlay_Eventfile_reader->readNextEvent(LCIO::UPDATE);
 

--- a/src/OverlayTimingRandomMix.cc
+++ b/src/OverlayTimingRandomMix.cc
@@ -407,6 +407,10 @@ namespace overlay
     {
       streamlog_out(DEBUG) << "Collection " << collection_names_in_evt->at(i) << " has now " << evt->getCollection(collection_names_in_evt->at(i))->getNumberOfElements() << " elements" << std::endl;
     }
+
+    // reset pointer
+    overlay_Evt = nullptr;
+
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a memory management issue that didn't properly close the Overlay input files at the end of the processing.
The change reduces by a factor 20 the memory needed to overlay the EU24 BIB files.



BEGINRELEASENOTES
- Improved memory management for OverlayTimingRandomMix and OverlayTiming processor by resetting pointer to closed files

ENDRELEASENOTES